### PR TITLE
Add restart notice to Lossless Artwork string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1599,7 +1599,7 @@
     <string name="settings_ignore_mediastore_covers">Ignore MediaStore Covers</string>
     <string name="settings_ignore_mediastore_covers_desc">Embedded album art</string>
     <string name="settings_lossless_artwork">Lossless Artwork</string>
-    <string name="settings_lossless_artwork_desc">Full-quality cover art, no downscaling. Uses more memory.</string>
+    <string name="settings_lossless_artwork_desc">Full-quality cover art, no downscaling. Uses more memory. Restart required.</string>
     <string name="settings_artist_parsing">Artists</string>
     <string name="settings_artist_parsing_desc">Separators, display</string>
     <string name="settings_rhythm_stats">Rhythm Stats</string>


### PR DESCRIPTION
## Description
Add restart notice to Lossless Artwork string to clarify that users will need to restart the app to see an effect.

(This was based off of my personal experience so it may have been an edge case but nonetheless I figured this change might help someone out there)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code style update (formatting, renaming)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Testing update

## How Has This Been Tested?
- [x] Manual testing on device/emulator
- [ ] Unit tests
- [ ] Integration tests
- [ ] Tested on multiple Android versions


## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested that my changes work as expected
- [ ] Any dependent changes have been merged and published
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Screenshots (if applicable)
Add screenshots to show visual changes.

## Additional Notes

(Locally edited APK directly to make change as i do not have a suitable machine to compile with)

Tried to match the style of the restart notice for Bit Perfect Mode.

also, i do see an odd symbol in the diff, I used the web editor for the commit after tinkering with the APK.
<img width="1299" height="88" alt="image" src="https://github.com/user-attachments/assets/fb788a5b-9771-4cff-8b05-2185698663e2" />
