### PR TITLE
Fix ArtistDetailScreen: Update album filtering

### DIFF
--- a/app/src/main/java/chromahub/rhythm/app/features/local/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/chromahub/rhythm/app/features/local/presentation/screens/ArtistDetailScreen.kt
@@ -162,8 +162,7 @@ fun ArtistDetailScreen(
             }
 
             val songs = allSongs.filter(::songMatchesArtist)
-            val albumKeys = songs.asSequence().map { it.albumId to it.album }.toSet()
-            val albums = allAlbums.filter { album -> albumKeys.contains(album.id to album.title) }
+            val albums = allAlbums.filter {album -> album.songs.any {song -> songMatchesArtist(song) } }
             ArtistDetailContent(songs = songs, albums = albums)
         }
     }


### PR DESCRIPTION
## Description
Fix overly sensitive album-artist matching to include any album with a song that matches the artist.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Testing update

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing on device/emulator
- [ ] Tested on multiple Android versions

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [x] I have tested that my changes work as expected
- [ ] ~~Any dependent changes have been merged and published~~

## Additional Notes
This fixes #427 