### PR TITLE
Allow user certificates to be used by the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         android:supportsRtl="true"
         android:localeConfig="@xml/locale_config"
         android:theme="@style/Theme.Rhythm"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:enableOnBackInvokedCallback="true"
         tools:targetApi="36">
         

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+	<base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration">
+		<trust-anchors>
+			<certificates src="system" />
+			<certificates src="user" tools:ignore="AcceptsUserCertificates" />
+		</trust-anchors>
+	</base-config>
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-	<base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration">
+	<base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration"><!--allows http traffic. i assume this is desired for maximum compatibility-->
 		<trust-anchors>
-			<certificates src="system" />
-			<certificates src="user" tools:ignore="AcceptsUserCertificates" />
+			<certificates src="system" /><!--default system-installed certificates-->
+			<certificates src="user" tools:ignore="AcceptsUserCertificates" /><!--user-installed certificates(surpressing warning about them)-->
 		</trust-anchors>
 	</base-config>
 </network-security-config>


### PR DESCRIPTION
## Description
I've fixed #451 by allowing user-imported rootCAs to be used by the app.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Testing update

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing on device/emulator
- [ ] Tested on multiple Android versions

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my changes work as expected
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to show visual changes.

## Additional Notes
Any additional information or context about this PR.