### PR TITLE
feat: add toggle for displaying remaining playback time in player UI

### DIFF
--- a/app/src/main/java/chromahub/rhythm/app/shared/data/model/AppSettings.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/data/model/AppSettings.kt
@@ -428,6 +428,7 @@ class AppSettings private constructor(context: Context) {
         private const val KEY_PLAYBACK_PITCH = "playback_pitch"
         private const val KEY_SYNC_SPEED_AND_PITCH = "sync_speed_and_pitch"
         private const val KEY_USE_HOURS_IN_TIME_FORMAT = "use_hours_in_time_format"
+        private const val KEY_SHOW_REMAINING_TIME = "show_remaining_time"
         private const val KEY_USE_EXACT_ARTWORK_COLORS = "use_exact_artwork_colors"
         private const val KEY_STOP_PLAYBACK_ON_APP_CLOSE = "stop_playback_on_app_close"
         private const val KEY_QUEUE_PERSISTENCE_ENABLED = "queue_persistence_enabled" // Enable/disable queue persistence
@@ -1053,6 +1054,9 @@ class AppSettings private constructor(context: Context) {
     // Time Format Settings - Show hours:minutes:seconds for longer tracks (>60 min)
     private val _useHoursInTimeFormat = MutableStateFlow(prefs.getBoolean(KEY_USE_HOURS_IN_TIME_FORMAT, true))
     val useHoursInTimeFormat: StateFlow<Boolean> = _useHoursInTimeFormat.asStateFlow()
+    
+    private val _showRemainingTime = MutableStateFlow(prefs.getBoolean(KEY_SHOW_REMAINING_TIME, false))
+    val showRemainingTime: StateFlow<Boolean> = _showRemainingTime.asStateFlow()
     
     // Exact extracted colors from artwork settings
     private val _useExactArtworkColors = MutableStateFlow(prefs.getBoolean(KEY_USE_EXACT_ARTWORK_COLORS, false))
@@ -2697,6 +2701,11 @@ private val _autoCheckForUpdates = MutableStateFlow(prefs.getBoolean(KEY_AUTO_CH
     fun setUseHoursInTimeFormat(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_USE_HOURS_IN_TIME_FORMAT, enabled).apply()
         _useHoursInTimeFormat.value = enabled
+    }
+    
+    fun setShowRemainingTime(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_SHOW_REMAINING_TIME, enabled).apply()
+        _showRemainingTime.value = enabled
     }
     
     // Exact extracted colors from artwork settings methods

--- a/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/ExpressivePlayerScreen.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/ExpressivePlayerScreen.kt
@@ -127,6 +127,7 @@ fun ExpressivePlayerScreen(
     progress: () -> Float,
     currentTimeStr: String,
     totalTimeStr: String,
+    onTotalTimeClick: () -> Unit = {},
     queuePosition: Int,
     queueTotal: Int,
     isShuffleEnabled: Boolean,
@@ -988,7 +989,10 @@ fun ExpressivePlayerScreen(
                                             Text(
                                                 text = totalTimeStr,
                                                 style = MaterialTheme.typography.labelMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier
+                                                    .padding(start = 12.dp, end = 4.dp, top = 8.dp, bottom = 8.dp)
+                                                    .clickable { onTotalTimeClick() }
                                             )
                                         }
                                     }

--- a/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/MaterialPlayerScreen.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/MaterialPlayerScreen.kt
@@ -10,6 +10,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.Spring
@@ -320,6 +322,7 @@ fun MaterialPlayerScreen(
     val artistSeparatorEnabled by appSettingsInstance.artistSeparatorEnabled.collectAsState()
     val artistSeparatorDelimiters by appSettingsInstance.artistSeparatorDelimiters.collectAsState()
     val useHoursFormat by appSettingsInstance.useHoursInTimeFormat.collectAsState()
+    val showRemainingTime by appSettingsInstance.showRemainingTime.collectAsState()
     val enableRatingSystem by appSettingsInstance.enableRatingSystem.collectAsState()
     
     // Player customization settings
@@ -782,19 +785,26 @@ fun MaterialPlayerScreen(
 
     // Calculate current and total time
     val totalTimeMs = song?.duration?.takeIf { it > 0 } ?: resolvedDurationMs.takeIf { it > 0 } ?: 0L
-    val currentTimeMs by remember(totalTimeMs) {
-        derivedStateOf { (totalTimeMs * progress()).toLong() }
-    }
+    val progressValue = progress().coerceIn(0f, 1f)
+    val currentTimeMs = (totalTimeMs * progressValue).toLong()
     val canSeek = totalTimeMs > 0
     
     // Calculate scrub preview time when enhanced seeking is active
     val scrubTimeMs = (totalTimeMs * scrubProgress).toLong()
 
-    // Format current and total time
-    val currentTimeFormatted by remember(totalTimeMs, useHoursFormat) {
-        derivedStateOf { formatDuration(currentTimeMs, useHoursFormat) }
+    // Format current and total time directly to ensure perfect sync
+    val currentSeconds = currentTimeMs / 1000
+    val totalSeconds = totalTimeMs / 1000
+    val remainingSeconds = (totalSeconds - currentSeconds).coerceAtLeast(0L)
+
+    val currentTimeFormatted = formatDuration(currentSeconds * 1000, useHoursFormat)
+    val totalTimeFormatted = if (showRemainingTime) {
+        "-" + formatDuration(remainingSeconds * 1000, useHoursFormat)
+    } else {
+        remember(totalTimeMs, useHoursFormat) {
+            formatDuration(totalSeconds * 1000, useHoursFormat)
+        }
     }
-    val totalTimeFormatted = formatDuration(totalTimeMs, useHoursFormat)
     val scrubTimeFormatted = formatDuration(scrubTimeMs, useHoursFormat)
 
     // Track previous queue position for slide direction
@@ -2636,6 +2646,7 @@ fun MaterialPlayerScreen(
 
                                 // Total time pill
                                 Surface(
+                                    onClick = { appSettingsInstance.setShowRemainingTime(!showRemainingTime) },
                                     shape = RoundedCornerShape(12.dp),
                                     color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
                                     modifier = Modifier.padding(horizontal = 2.dp, vertical = 1.dp)

--- a/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/player/PlayerScreen.kt
@@ -235,9 +235,24 @@ fun PlayerScreen(
         if (playerThemeId == "EXPRESSIVE") {
         val haptic = LocalHapticFeedback.current
         val useHoursFormat by appSettings.useHoursInTimeFormat.collectAsState()
+        val showRemainingTime by appSettings.showRemainingTime.collectAsState()
         val progressValue = progress().coerceIn(0f, 1f)
         val totalTimeMs = song?.duration ?: 0L
         val currentTimeMs = (progressValue * totalTimeMs).toLong()
+        
+        val currentSeconds = currentTimeMs / 1000
+        val totalSeconds = totalTimeMs / 1000
+        val remainingSeconds = (totalSeconds - currentSeconds).coerceAtLeast(0L)
+        
+        val currentTimeStr = formatDuration(currentSeconds * 1000, useHoursFormat)
+        val totalTimeFormatted = remember(totalTimeMs, useHoursFormat) {
+            formatDuration(totalSeconds * 1000, useHoursFormat)
+        }
+        val totalTimeStr = if (showRemainingTime) {
+            "-" + formatDuration(remainingSeconds * 1000, useHoursFormat)
+        } else {
+            totalTimeFormatted
+        }
 
         var showQueueSheet by remember { mutableStateOf(false) }
         var showSongInfoSheet by remember { mutableStateOf(false) }
@@ -356,8 +371,9 @@ fun PlayerScreen(
             isPlaying = isPlaying,
             isFavorite = isFavorite,
             progress = { progressValue },
-            currentTimeStr = formatDuration(currentTimeMs, useHoursFormat),
-            totalTimeStr = formatDuration(totalTimeMs, useHoursFormat),
+            currentTimeStr = currentTimeStr,
+            totalTimeStr = totalTimeStr,
+            onTotalTimeClick = { appSettings.setShowRemainingTime(!showRemainingTime) },
             queuePosition = queuePosition,
             queueTotal = queueTotal,
             isShuffleEnabled = isShuffleEnabled,

--- a/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/settings/PlaybackSettingsScreen.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/settings/PlaybackSettingsScreen.kt
@@ -55,6 +55,7 @@ fun PlaybackSettingsScreen(
     val repeatModePersistence by appSettings.repeatModePersistence.collectAsState()
     val shuffleModePersistence by appSettings.shuffleModePersistence.collectAsState()
     val useHoursInTimeFormat by appSettings.useHoursInTimeFormat.collectAsState()
+    val showRemainingTime by appSettings.showRemainingTime.collectAsState()
     val gaplessEnabled by appSettings.gaplessPlayback.collectAsState()
     val crossfadeEnabled by appSettings.crossfade.collectAsState()
     val crossfadeDuration by appSettings.crossfadeDuration.collectAsState()
@@ -185,6 +186,13 @@ fun PlaybackSettingsScreen(
                         if (useHoursInTimeFormat) context.getString(R.string.settings_use_hours_enabled) else context.getString(R.string.settings_use_hours_disabled),
                         toggleState = useHoursInTimeFormat,
                         onToggleChange = { appSettings.setUseHoursInTimeFormat(it) }
+                    ),
+                    SettingItem(
+                        RhythmIcons.AccessTime,
+                        context.getString(R.string.settings_show_remaining_time),
+                        context.getString(R.string.settings_show_remaining_time_desc),
+                        toggleState = showRemainingTime,
+                        onToggleChange = { appSettings.setShowRemainingTime(it) }
                     )
                 )
             )

--- a/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/settings/SettingsSearch.kt
+++ b/app/src/main/java/chromahub/rhythm/app/shared/presentation/screens/settings/SettingsSearch.kt
@@ -1284,6 +1284,16 @@ fun buildSettingsSearchIndex(context: Context): List<SearchableSettingItem> {
             settingKey = "useHoursInTimeFormat"
         ))
         add(SearchableSettingItem(
+            id = "show_remaining_time",
+            title = context.getString(R.string.settings_show_remaining_time),
+            description = context.getString(R.string.settings_show_remaining_time_desc),
+            keywords = listOf("remaining", "time", "duration", "display", "countdown", "total"),
+            icon = RhythmIcons.AccessTime,
+            route = SettingsRoutes.PLAYBACK,
+            parentScreen = "Playback",
+            settingKey = "showRemainingTime"
+        ))
+        add(SearchableSettingItem(
             id = "gapless_playback",
             title = context.getString(R.string.settings_gapless_playback),
             description = context.getString(R.string.settings_gapless_playback_desc),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="settings_use_hours">Use Hour Format</string>
     <string name="settings_use_hours_enabled">Shows 1:32:26 for long tracks</string>
     <string name="settings_use_hours_disabled">Shows 92:26 for long tracks</string>
+    <string name="settings_show_remaining_time">Show Remaining Time</string>
+    <string name="settings_show_remaining_time_desc">Display remaining playback duration in player screens</string>
 <string name="settings_playlists">Playlists</string>
     <string name="settings_playlists_overview">Overview</string>
     <string name="settings_playlists_management">Management</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "9.3.0"
 kotlin = "2.4.10"
 ksp = "2.3.6"
 coreKtx = "1.19.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.0"
+agp = "9.2.1"
 kotlin = "2.4.10"
 ksp = "2.3.6"
 coreKtx = "1.19.0"


### PR DESCRIPTION
## Description
Implement the ability to toggle between total track duration and remaining time (prefixed with `-`) in both the Material and Expressive player UIs.

Key details:
- Added persistent toggle `showRemainingTime` in `AppSettings`.
- Added setting toggle option for remaining playback time under Settings > Playback > Time Format.
- Tapping total/remaining time pill (Material) or total time label (Expressive) switches the display mode.
- Synchronized playback times exactly to the millisecond by truncating times to whole seconds first, avoiding mathematical desync when track duration is not an exact multiple of 1000ms.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Testing update

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing on device/emulator
- [x] Tested on multiple Android versions

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my changes work as expected
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
<img width="368" height="89" alt="image" src="https://github.com/user-attachments/assets/bb09e6fb-035d-431e-b3c8-0824ed6a8e08" />

<img width="355" height="63" alt="image" src="https://github.com/user-attachments/assets/ac0ba698-903a-4840-af62-a1d1ef343c0d" />

## Additional Notes
All unit tests (`:app:testGithubDebugUnitTest`) pass successfully. Note that standard system media controls (Quick Settings / Lockscreen players) are rendered directly by the Android System UI from active `MediaSession` progress state; third-party apps cannot customize elapsed vs remaining indicators there, but Android OS supports user toggling by tapping the time indicator directly on many Android versions.
